### PR TITLE
Update dockerfile to newer node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10
+FROM node:16
 
 RUN npm install -g --unsafe-perm @ironcorelabs/ironhide
 COPY entrypoint.sh /


### PR DESCRIPTION
`ironhide` now (0.8.0) runs on node 14 and 16, updating to 16.