### PR TITLE
Make action check if it's already been run in the job

### DIFF
--- a/decrypt/action.yml
+++ b/decrypt/action.yml
@@ -11,24 +11,25 @@ runs:
   using: composite
   steps:
     - name: Set env vars (Linux)
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' && env.IRONHIDE_INSTALLED != true
       shell: bash
       run: |
         echo FILE_PATTERN='*linux-musl*' >> $GITHUB_ENV
         echo UNZIP_CMD='tar -xf *linux-musl*' >> $GITHUB_ENV
     - name: Set env vars (macOS)
-      if: runner.os == 'macOS'
+      if: runner.os == 'macOS' && env.IRONHIDE_INSTALLED != true
       shell: bash
       run: |
         echo FILE_PATTERN='*apple-darwin*' >> $GITHUB_ENV
         echo UNZIP_CMD='tar -xf *apple-darwin*' >> $GITHUB_ENV
     - name: Set env vars (Windows)
-      if: runner.os == 'Windows'
+      if: runner.os == 'Windows' && env.IRONHIDE_INSTALLED != true
       shell: bash
       run: |
         echo FILE_PATTERN='*windows-msvc*' >> $GITHUB_ENV
         echo UNZIP_CMD='7z x *windows-msvc*' >> $GITHUB_ENV
     - name: Download ironhide release
+      if: env.IRONHIDE_INSTALLED != true
       uses: robinraju/release-downloader@v1.7
       with:
         repository: "IronCoreLabs/ironhide"
@@ -36,16 +37,18 @@ runs:
         latest: true
         tarBall: true
         zipBall: true
-    - name: Unzip and rename
+    - name: Unzip and install ironhide
+      if: env.IRONHIDE_INSTALLED != true
       shell: bash
       run: |
         ${{ env.UNZIP_CMD }}
         rm -rf ${{ env.FILE_PATTERN }}.gz
         rm -rf ${{ env.FILE_PATTERN }}.zip
         mv ${{ env.FILE_PATTERN }}/ironhide* ironhide
-    - name: Set keys and decrypt
-      shell: bash
-      run: |
+        rm -rf ${{ env.FILE_PATTERN }}
         mkdir -p ~/.iron
         echo '${{ inputs.keys }}' > ~/.iron/keys
-        ./ironhide file decrypt ${{ inputs.input }}
+        echo IRONHIDE_INSTALLED=true >> $GITHUB_ENV
+    - name: Decrypt file
+      shell: bash
+      run: ./ironhide file decrypt ${{ inputs.input }}

--- a/decrypt/action.yml
+++ b/decrypt/action.yml
@@ -50,4 +50,4 @@ runs:
       shell: bash
       run: |
         ./ironhide file decrypt ${{ inputs.input }}
-        echo 'Decryption of ${{ inputs.input }} was successful'
+        echo 'Decryption of [${{ inputs.input }}] was successful!'

--- a/decrypt/action.yml
+++ b/decrypt/action.yml
@@ -42,10 +42,10 @@ runs:
         ${{ env.UNZIP_CMD }}
         rm -rf ${{ env.FILE_PATTERN }}.gz
         rm -rf ${{ env.FILE_PATTERN }}.zip
-        mv ${{ env.FILE_PATTERN }} ironhide
+        mv ${{ env.FILE_PATTERN }}/ironhide* ironhide
     - name: Set keys and decrypt
       shell: bash
       run: |
         mkdir -p ~/.iron
         echo '${{ inputs.keys }}' > ~/.iron/keys
-        ironhide/ironhide file decrypt ${{ inputs.input }}
+        ironhide file decrypt ${{ inputs.input }}

--- a/decrypt/action.yml
+++ b/decrypt/action.yml
@@ -42,13 +42,12 @@ runs:
       shell: bash
       run: |
         ${{ env.UNZIP_CMD }}
-        rm -rf ${{ env.FILE_PATTERN }}.gz
-        rm -rf ${{ env.FILE_PATTERN }}.zip
         mv ${{ env.FILE_PATTERN }}/ironhide* ironhide
-        rm -rf ${{ env.FILE_PATTERN }}
         mkdir -p ~/.iron
         echo '${{ inputs.keys }}' > ~/.iron/keys
         echo IRONHIDE_INSTALLED=true >> $GITHUB_ENV
     - name: Decrypt file
       shell: bash
-      run: ./ironhide file decrypt ${{ inputs.input }}
+      run: |
+        ./ironhide file decrypt ${{ inputs.input }}
+        echo 'Decryption of ${{ inputs.input }} was successful'

--- a/decrypt/action.yml
+++ b/decrypt/action.yml
@@ -29,7 +29,7 @@ runs:
         echo FILE_PATTERN='*windows-msvc*' >> $GITHUB_ENV
         echo UNZIP_CMD='7z x *windows-msvc*' >> $GITHUB_ENV
     - name: Download ironhide release
-      uses: robinraju/release-downloader@v1.6
+      uses: robinraju/release-downloader@v1.7
       with:
         repository: "IronCoreLabs/ironhide"
         fileName: ${{ env.FILE_PATTERN }}
@@ -48,4 +48,4 @@ runs:
       run: |
         mkdir -p ~/.iron
         echo '${{ inputs.keys }}' > ~/.iron/keys
-        ironhide file decrypt ${{ inputs.input }}
+        ./ironhide file decrypt ${{ inputs.input }}

--- a/decrypt/action.yml
+++ b/decrypt/action.yml
@@ -11,25 +11,25 @@ runs:
   using: composite
   steps:
     - name: Set env vars (Linux)
-      if: ${{ runner.os == 'Linux' && env.IRONHIDE_INSTALLED != "true" }}
+      if: ${{ runner.os == 'Linux' && env.IRONHIDE_INSTALLED != 'true' }}
       shell: bash
       run: |
         echo FILE_PATTERN='*linux-musl*' >> $GITHUB_ENV
         echo UNZIP_CMD='tar -xf *linux-musl*' >> $GITHUB_ENV
     - name: Set env vars (macOS)
-      if: ${{ runner.os == 'macOS' && env.IRONHIDE_INSTALLED != "true" }}
+      if: ${{ runner.os == 'macOS' && env.IRONHIDE_INSTALLED != 'true' }}
       shell: bash
       run: |
         echo FILE_PATTERN='*apple-darwin*' >> $GITHUB_ENV
         echo UNZIP_CMD='tar -xf *apple-darwin*' >> $GITHUB_ENV
     - name: Set env vars (Windows)
-      if: ${{ runner.os == 'Windows' && env.IRONHIDE_INSTALLED != "true" }}
+      if: ${{ runner.os == 'Windows' && env.IRONHIDE_INSTALLED != 'true' }}
       shell: bash
       run: |
         echo FILE_PATTERN='*windows-msvc*' >> $GITHUB_ENV
         echo UNZIP_CMD='7z x *windows-msvc*' >> $GITHUB_ENV
     - name: Download ironhide release
-      if: env.IRONHIDE_INSTALLED != "true"
+      if: env.IRONHIDE_INSTALLED != 'true'
       uses: robinraju/release-downloader@v1.7
       with:
         repository: "IronCoreLabs/ironhide"
@@ -38,7 +38,7 @@ runs:
         tarBall: true
         zipBall: true
     - name: Unzip and install ironhide
-      if: env.IRONHIDE_INSTALLED != true
+      if: env.IRONHIDE_INSTALLED != 'true'
       shell: bash
       run: |
         ${{ env.UNZIP_CMD }}

--- a/decrypt/action.yml
+++ b/decrypt/action.yml
@@ -11,25 +11,25 @@ runs:
   using: composite
   steps:
     - name: Set env vars (Linux)
-      if: runner.os == 'Linux' && env.IRONHIDE_INSTALLED != true
+      if: ${{ runner.os == 'Linux' && env.IRONHIDE_INSTALLED != "true" }}
       shell: bash
       run: |
         echo FILE_PATTERN='*linux-musl*' >> $GITHUB_ENV
         echo UNZIP_CMD='tar -xf *linux-musl*' >> $GITHUB_ENV
     - name: Set env vars (macOS)
-      if: runner.os == 'macOS' && env.IRONHIDE_INSTALLED != true
+      if: ${{ runner.os == 'macOS' && env.IRONHIDE_INSTALLED != "true" }}
       shell: bash
       run: |
         echo FILE_PATTERN='*apple-darwin*' >> $GITHUB_ENV
         echo UNZIP_CMD='tar -xf *apple-darwin*' >> $GITHUB_ENV
     - name: Set env vars (Windows)
-      if: runner.os == 'Windows' && env.IRONHIDE_INSTALLED != true
+      if: ${{ runner.os == 'Windows' && env.IRONHIDE_INSTALLED != "true" }}
       shell: bash
       run: |
         echo FILE_PATTERN='*windows-msvc*' >> $GITHUB_ENV
         echo UNZIP_CMD='7z x *windows-msvc*' >> $GITHUB_ENV
     - name: Download ironhide release
-      if: env.IRONHIDE_INSTALLED != true
+      if: env.IRONHIDE_INSTALLED != "true"
       uses: robinraju/release-downloader@v1.7
       with:
         repository: "IronCoreLabs/ironhide"


### PR DESCRIPTION
After installing ironhide, it sets IRONHIDE_INSTALLED=true, and all the installation steps check for this before running. I tested and confirmed that environment variables set inside of this action are propagated to the calling action _and_ to the subsequent calls to this action. This should fix the issue with calling the action multiple times in one job.