### PR TITLE
Change the decrypt shell so that ironhide still outputs stdout log lines

### DIFF
--- a/decrypt/action.yml
+++ b/decrypt/action.yml
@@ -51,7 +51,8 @@ runs:
       echo '${{ inputs.keys }}' > ~/.iron/keys
       echo IRONHIDE_INSTALLED=true >> $GITHUB_ENV
   - name: Decrypt file
-    shell: bash
+    # hack to get a tty in github so ironhide prints output
+    shell: 'script -q -e -c "bash {0}"'
     run: |
       ./ironhide file decrypt ${{ inputs.input }}
       echo 'Decryption of [${{ inputs.input }}] was successful!'

--- a/decrypt/action.yml
+++ b/decrypt/action.yml
@@ -54,5 +54,6 @@ runs:
     # hack to get a tty in github so ironhide prints output
     shell: 'script -q -e -c "bash {0}"'
     run: |
+      set -e
       ./ironhide file decrypt ${{ inputs.input }}
       echo 'Decryption of [${{ inputs.input }}] was successful!'


### PR DESCRIPTION
An internally visible test run of this is [here](https://github.com/IronCoreLabs/actions-test/actions/runs/4535653314/jobs/7991365999).

This is to solve an observed problem that the decrypt action won't print useful error context because github actions don't run in a tty. We get something that ironhide detects as a tty to get around this.