### PR TITLE
Make action clean up after itself

### DIFF
--- a/decrypt/action.yml
+++ b/decrypt/action.yml
@@ -59,11 +59,7 @@ runs:
     if: steps.setup.outputs.installed != 'true'
     shell: bash
     run: |
-      if [ "${{ runner.os }}" = "Windows" ]; then
-        mv ironhide_download/${{ steps.setup.outputs.file_pattern }}/ironhide* '${{ runner.temp }}'/ironhide
-      else
-        mv ironhide_download/${{ steps.setup.outputs.file_pattern }}/ironhide* ${{ runner.temp }}/ironhide
-      fi 
+      mv ironhide_download/${{ steps.setup.outputs.file_pattern }}/ironhide* '${{ runner.temp }}'/ironhide
       rm -rf ironhide_download
       rm -rf typescript
       mkdir -p ~/.iron
@@ -73,14 +69,14 @@ runs:
     # hack to get a tty in github so ironhide prints output
     shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
     run: |
-      ${{ runner.temp }}/ironhide file decrypt ${{ inputs.input }}
+      '${{ runner.temp }}'/ironhide file decrypt ${{ inputs.input }}
       echo 'Decryption of [${{ inputs.input }}] was successful!'
   - name: Decrypt file
     if: runner.os == 'macOS'
     # hack to get a tty in github so ironhide prints output
     shell: 'script -Fq /dev/null /bin/sh -c "bash --noprofile --norc -eo pipefail {0}"'
     run: |
-      ${{ runner.temp }}/ironhide file decrypt ${{ inputs.input }}
+      '${{ runner.temp }}'/ironhide file decrypt ${{ inputs.input }}
       echo 'Decryption of [${{ inputs.input }}] was successful!'
   - name: Decrypt file
     if: runner.os == 'Windows'

--- a/decrypt/action.yml
+++ b/decrypt/action.yml
@@ -61,7 +61,7 @@ runs:
     run: |
       if [ "${{ runner.os }}" = "Windows" ]; then
         # `runner.temp` (${{ runner.temp }}) is currently bugged on Windows
-        mv ironhide_download/${{ steps.setup.outputs.file_pattern }}/ironhide* D:/a_temp/ironhide
+        mv ironhide_download\\${{ steps.setup.outputs.file_pattern }}\\ironhide* D:\\a_temp\\ironhide
       else
         mv ironhide_download/${{ steps.setup.outputs.file_pattern }}/ironhide* ${{ runner.temp }}/ironhide
       fi 

--- a/decrypt/action.yml
+++ b/decrypt/action.yml
@@ -60,7 +60,7 @@ runs:
     shell: bash
     run: |
       if [ "${{ runner.os }}" = "Windows" ]; then
-        mv ironhide_download\\${{ steps.setup.outputs.file_pattern }}\\ironhide* ${{ runner.temp }}\\ironhide  
+        mv ironhide_download/${{ steps.setup.outputs.file_pattern }}/ironhide* ${{ runner.temp }}\\ironhide
       else
         mv ironhide_download/${{ steps.setup.outputs.file_pattern }}/ironhide* ${{ runner.temp }}/ironhide
       fi 

--- a/decrypt/action.yml
+++ b/decrypt/action.yml
@@ -23,18 +23,18 @@ runs:
       case ${{ runner.os }} in
         Linux)
           if ["${{ runner.arch }}" = "ARM64"]; then
-            echo "file_pattern='*aarch64-unknown-linux*'" >> "$GITHUB_OUTPUT"
+            echo 'file_pattern=*aarch64-unknown-linux*' >> "$GITHUB_OUTPUT"
           else
-            echo "file_pattern='*linux-musl*'" >> "$GITHUB_OUTPUT"
+            echo 'file_pattern=*linux-musl*' >> "$GITHUB_OUTPUT"
           fi
           ;;
 
         macOS)
-          echo "file_pattern='*apple-darwin*'" >> "$GITHUB_OUTPUT"
+          echo 'file_pattern=*apple-darwin*' >> "$GITHUB_OUTPUT"
           ;;
 
         Windows)
-          echo "file_pattern='*windows-msvc*'" >> "$GITHUB_OUTPUT"
+          echo 'file_pattern=*windows-msvc*' >> "$GITHUB_OUTPUT"
           ;;
 
         *)

--- a/decrypt/action.yml
+++ b/decrypt/action.yml
@@ -59,7 +59,11 @@ runs:
     if: steps.setup.outputs.installed != 'true'
     shell: bash
     run: |
-      mv ironhide_download/${{ steps.setup.outputs.file_pattern }}/ironhide* /${{ runner.temp }}/ironhide
+      if [ "${{ runner.os }}" = "Windows" ]; then
+        mv ironhide_download\\${{ steps.setup.outputs.file_pattern }}\\ironhide* ${{ runner.temp }}\\ironhide  
+      else
+        mv ironhide_download/${{ steps.setup.outputs.file_pattern }}/ironhide* ${{ runner.temp }}/ironhide
+      fi 
       rm -rf ironhide_download
       rm -rf typescript
       mkdir -p ~/.iron

--- a/decrypt/action.yml
+++ b/decrypt/action.yml
@@ -22,7 +22,7 @@ runs:
 
       case ${{ runner.os }} in
         Linux)
-          if ["${{ runner.arch }}" = "ARM64"]; then
+          if [ "${{ runner.arch }}" = "ARM64" ]; then
             echo 'file_pattern=*aarch64-unknown-linux*' >> "$GITHUB_OUTPUT"
           else
             echo 'file_pattern=*linux-musl*' >> "$GITHUB_OUTPUT"
@@ -30,7 +30,7 @@ runs:
           ;;
 
         macOS)
-          if ["${{ runner.arch }}" = "ARM64"]; then
+          if [ "${{ runner.arch }}" = "ARM64" ]; then
             echo 'file_pattern=*aarch64-apple-darwin*' >> "$GITHUB_OUTPUT"
           else
             echo 'file_pattern=*x86_64-apple-darwin*' >> "$GITHUB_OUTPUT"

--- a/decrypt/action.yml
+++ b/decrypt/action.yml
@@ -30,7 +30,11 @@ runs:
           ;;
 
         macOS)
-          echo 'file_pattern=*apple-darwin*' >> "$GITHUB_OUTPUT"
+          if ["${{ runner.arch }}" = "ARM64"]; then
+            echo 'file_pattern=*aarch64-apple-darwin*' >> "$GITHUB_OUTPUT"
+          else
+            echo 'file_pattern=*x86_64-apple-darwin*' >> "$GITHUB_OUTPUT"
+          fi
           ;;
 
         Windows)
@@ -57,7 +61,7 @@ runs:
     run: |
       mv ironhide_download/${{ steps.setup.outputs.file_pattern }}/ironhide* ${{ runner.temp }}/ironhide
       rm -rf ironhide_download
-      ls -al
+      rm -rf typescript
       mkdir -p ~/.iron
       echo '${{ inputs.keys }}' > ~/.iron/keys
   - name: Decrypt file

--- a/decrypt/action.yml
+++ b/decrypt/action.yml
@@ -59,8 +59,7 @@ runs:
     if: steps.setup.outputs.installed != 'true'
     shell: bash
     run: |
-      mkdir ${{ runner.temp }}
-      mv ironhide_download/${{ steps.setup.outputs.file_pattern }}/ironhide* ${{ runner.temp }}/ironhide
+      mv ironhide_download/${{ steps.setup.outputs.file_pattern }}/ironhide* /${{ runner.temp }}/ironhide
       rm -rf ironhide_download
       rm -rf typescript
       mkdir -p ~/.iron

--- a/decrypt/action.yml
+++ b/decrypt/action.yml
@@ -59,6 +59,7 @@ runs:
     if: steps.setup.outputs.installed != 'true'
     shell: bash
     run: |
+      mkdir ${{ runner.temp }}
       mv ironhide_download/${{ steps.setup.outputs.file_pattern }}/ironhide* ${{ runner.temp }}/ironhide
       rm -rf ironhide_download
       rm -rf typescript

--- a/decrypt/action.yml
+++ b/decrypt/action.yml
@@ -10,64 +10,74 @@ inputs:
 runs:
   using: composite
   steps:
-  - name: Set env vars (Linux arm64)
-    if: ${{ runner.os == 'Linux' && runner.arch == 'ARM64' && env.IRONHIDE_INSTALLED != 'true' }}
+  - name: Set up environment
+    id: setup
     shell: bash
     run: |
-      echo FILE_PATTERN='*aarch64-unknown-linux*' >> $GITHUB_ENV
-      echo UNZIP_CMD='tar -xf *aarch64-unknown-linux*' >> $GITHUB_ENV
-  - name: Set env vars (Linux x86_64)
-    if: ${{ runner.os == 'Linux' && runner.arch != 'ARM64' && env.IRONHIDE_INSTALLED != 'true' }}
-    shell: bash
-    run: |
-      echo FILE_PATTERN='*linux-musl*' >> $GITHUB_ENV
-      echo UNZIP_CMD='tar -xf *linux-musl*' >> $GITHUB_ENV
-  - name: Set env vars (macOS)
-    if: ${{ runner.os == 'macOS' && env.IRONHIDE_INSTALLED != 'true' }}
-    shell: bash
-    run: |
-      echo FILE_PATTERN='*apple-darwin*' >> $GITHUB_ENV
-      echo UNZIP_CMD='tar -xf *apple-darwin*' >> $GITHUB_ENV
-  - name: Set env vars (Windows)
-    if: ${{ runner.os == 'Windows' && env.IRONHIDE_INSTALLED != 'true' }}
-    shell: bash
-    run: |
-      echo FILE_PATTERN='*windows-msvc*' >> $GITHUB_ENV
-      echo UNZIP_CMD='7z x *windows-msvc*' >> $GITHUB_ENV
+      if [ -f ${{ runner.temp }}/ironhide ]; then
+        echo "ironhide is already installed."
+        echo "installed=true" >> "$GITHUB_OUTPUT"
+        exit 0
+      fi
+
+      case ${{ runner.os }} in
+        Linux)
+          if ["${{ runner.arch }}" = "ARM64"]; then
+            echo "file_pattern='*aarch64-unknown-linux*'" >> "$GITHUB_OUTPUT"
+          else
+            echo "file_pattern='*linux-musl*'" >> "$GITHUB_OUTPUT"
+          fi
+          ;;
+
+        macOS)
+          echo "file_pattern='*apple-darwin*'" >> "$GITHUB_OUTPUT"
+          ;;
+
+        Windows)
+          echo "file_pattern='*windows-msvc*'" >> "$GITHUB_OUTPUT"
+          ;;
+
+        *)
+          echo "Unknown runner os `${{ runner.os }}`."
+          exit 1
+          ;;
+      esac
   - name: Download ironhide release
-    if: env.IRONHIDE_INSTALLED != 'true'
-    uses: robinraju/release-downloader@v1.7
+    if: steps.setup.outputs.installed != 'true'
+    uses: robinraju/release-downloader@v1.8
     with:
       repository: "IronCoreLabs/ironhide"
-      fileName: ${{ env.FILE_PATTERN }}
+      fileName: ${{ steps.setup.outputs.file_pattern }}
       latest: true
-  - name: Unzip and install ironhide
-    if: env.IRONHIDE_INSTALLED != 'true'
+      extract: true
+      out-file-path: ironhide_download
+  - name: Install ironhide
+    if: steps.setup.outputs.installed != 'true'
     shell: bash
     run: |
-      ${{ env.UNZIP_CMD }}
-      mv ${{ env.FILE_PATTERN }}/ironhide* ironhide
+      mv ironhide_download/${{ steps.setup.outputs.file_pattern }}/ironhide* ${{ runner.temp }}/ironhide
+      rm -rf ironhide_download
+      ls -al
       mkdir -p ~/.iron
       echo '${{ inputs.keys }}' > ~/.iron/keys
-      echo IRONHIDE_INSTALLED=true >> $GITHUB_ENV
   - name: Decrypt file
-    if: ${{ runner.os == 'Linux' }}
+    if: runner.os == 'Linux'
     # hack to get a tty in github so ironhide prints output
     shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
     run: |
-      ./ironhide file decrypt ${{ inputs.input }}
+      ${{ runner.temp }}/ironhide file decrypt ${{ inputs.input }}
       echo 'Decryption of [${{ inputs.input }}] was successful!'
   - name: Decrypt file
-    if: ${{ runner.os == 'macOS' }}
+    if: runner.os == 'macOS'
     # hack to get a tty in github so ironhide prints output
     shell: 'script -Fq /dev/null /bin/sh -c "bash --noprofile --norc -eo pipefail {0}"'
     run: |
-      ./ironhide file decrypt ${{ inputs.input }}
+      ${{ runner.temp }}/ironhide file decrypt ${{ inputs.input }}
       echo 'Decryption of [${{ inputs.input }}] was successful!'
   - name: Decrypt file
-    if: ${{ runner.os == 'Windows' }}
+    if: runner.os == 'Windows'
     # we can't fake a tty on windows, so error output here is a bit worse
     shell: bash
     run: |
-      ./ironhide file decrypt ${{ inputs.input }}
+      ${{ runner.temp }}/ironhide file decrypt ${{ inputs.input }}
       echo 'Decryption of [${{ inputs.input }}] was successful!'

--- a/decrypt/action.yml
+++ b/decrypt/action.yml
@@ -60,7 +60,8 @@ runs:
     shell: bash
     run: |
       if [ "${{ runner.os }}" = "Windows" ]; then
-        mv ironhide_download/${{ steps.setup.outputs.file_pattern }}/ironhide* ${{ runner.temp }}\\ironhide
+        # `runner.temp` (${{ runner.temp }}) is currently bugged on Windows
+        mv ironhide_download/${{ steps.setup.outputs.file_pattern }}/ironhide* D:/a_temp/ironhide
       else
         mv ironhide_download/${{ steps.setup.outputs.file_pattern }}/ironhide* ${{ runner.temp }}/ironhide
       fi 
@@ -87,5 +88,6 @@ runs:
     # we can't fake a tty on windows, so error output here is a bit worse
     shell: bash
     run: |
-      ${{ runner.temp }}/ironhide file decrypt ${{ inputs.input }}
+      # `runner.temp` (${{ runner.temp }}) is currently bugged on Windows
+      D:/a_temp/ironhide file decrypt ${{ inputs.input }}
       echo 'Decryption of [${{ inputs.input }}] was successful!'

--- a/decrypt/action.yml
+++ b/decrypt/action.yml
@@ -60,8 +60,7 @@ runs:
     shell: bash
     run: |
       if [ "${{ runner.os }}" = "Windows" ]; then
-        # `runner.temp` (${{ runner.temp }}) is currently bugged on Windows
-        mv ironhide_download\\${{ steps.setup.outputs.file_pattern }}\\ironhide* D:\\a_temp\\ironhide
+        mv ironhide_download/${{ steps.setup.outputs.file_pattern }}/ironhide* '${{ runner.temp }}'/ironhide
       else
         mv ironhide_download/${{ steps.setup.outputs.file_pattern }}/ironhide* ${{ runner.temp }}/ironhide
       fi 
@@ -88,6 +87,5 @@ runs:
     # we can't fake a tty on windows, so error output here is a bit worse
     shell: bash
     run: |
-      # `runner.temp` (${{ runner.temp }}) is currently bugged on Windows
-      D:/a_temp/ironhide file decrypt ${{ inputs.input }}
+      '${{ runner.temp }}'/ironhide file decrypt ${{ inputs.input }}
       echo 'Decryption of [${{ inputs.input }}] was successful!'

--- a/decrypt/action.yml
+++ b/decrypt/action.yml
@@ -14,7 +14,7 @@ runs:
     id: setup
     shell: bash
     run: |
-      if [ -f ${{ runner.temp }}/ironhide ]; then
+      if [ -f '${{ runner.temp }}'/ironhide ]; then
         echo "ironhide is already installed."
         echo "installed=true" >> "$GITHUB_OUTPUT"
         exit 0


### PR DESCRIPTION
Also various improvements:
- Use GITHUB_OUTPUT instead of GITHUB_ENV so we don't pollute the environment of the caller
- Collapse conditional steps into 1 so we can use bash conditionals (and `else`s)
- Use release-downloader to extract, removing the need for custom unzip commands

Example of runs on all our different machine types here https://github.com/IronCoreLabs/actions-test/actions/runs/6748984416/job/18348499661